### PR TITLE
Revert "Make account config input an `input` so it takes up less space"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -71,7 +71,7 @@ body:
     validations:
       required: false
 
-  - type: input
+  - type: textarea
     attributes:
       label: Account config
       description: If your issue only happens when logged in, please provide your config. To export your config, go to the Settings page, scroll all the way down to `import/export settings` and click `export`.


### PR DESCRIPTION
Reverts UnrealApex/monkeytype#49